### PR TITLE
Adding transaction paths to routes file

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,3 +3,5 @@ group: api
 weight: 900
 routes:
   1: ^/persons-with-significant-control-verification
+  2: ^/transactions/.*/persons-with-significant-control-verification
+  3: ^/private/transactions/.*/persons-with-significant-control


### PR DESCRIPTION
Necessary to test IDVA3-490 in e2e environment.

This is the same as our psc-filing-api.  The `filing_resource_id` we have in the Docker Traefik path doesn't seem to need to be included.