### PR TITLE
Add validation when no PSC ID (PSC appoint ID) has been supplied

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/config/ValidatorConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/config/ValidatorConfig.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.pscverificationapi.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
+import uk.gov.companieshouse.pscverificationapi.validator.PscIdProvidedValidator;
 import uk.gov.companieshouse.pscverificationapi.validator.ValidationChainEnable;
 import uk.gov.companieshouse.pscverificationapi.validator.VerificationValidationChain;
 import uk.gov.companieshouse.pscverificationapi.validator.PscExistsValidator;
@@ -11,16 +12,19 @@ import uk.gov.companieshouse.pscverificationapi.validator.PscIsActiveValidator;
 @Configuration
 public class ValidatorConfig {
 
-    //TODO - handle the psc type better?
+    //Currently configured to validate individual PSCs
+    //TODO add a 2nd validation chain for the RLE journey if required
 
     @Bean
-    public ValidationChainEnable verificationValidationEnable(final PscExistsValidator pscExistsValidator, final PscIsActiveValidator pscIsActiveValidator) {
-        createValidationChain(pscExistsValidator, pscIsActiveValidator);
+    public ValidationChainEnable verificationValidationEnable(final PscIdProvidedValidator pscIdProvidedValidator, final PscExistsValidator pscExistsValidator, final PscIsActiveValidator pscIsActiveValidator) {
+        createValidationChain(pscIdProvidedValidator, pscExistsValidator, pscIsActiveValidator);
 
-        return new VerificationValidationChain(PscType.INDIVIDUAL, pscExistsValidator);
+        return new VerificationValidationChain(PscType.INDIVIDUAL, pscIdProvidedValidator);
     }
 
-    private static void createValidationChain(final PscExistsValidator pscExistsValidator, final PscIsActiveValidator pscIsActiveValidator) {
+    private static void createValidationChain(final PscIdProvidedValidator pscIdProvidedValidator,
+        final PscExistsValidator pscExistsValidator, final PscIsActiveValidator pscIsActiveValidator) {
+        pscIdProvidedValidator.setNext(pscExistsValidator);
 
         pscExistsValidator.setNext(pscIsActiveValidator);
 

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscExistsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscExistsValidator.java
@@ -26,7 +26,6 @@ public class PscExistsValidator extends BaseVerificationValidator implements Ver
         try {
             pscLookupService.getPsc(validationContext.transaction(), validationContext.dto(), validationContext.pscType(),
                 validationContext.passthroughHeader());
-            //TODO - handle - Validation should not continue if the PSC does not exist
         }
         catch (FilingResourceNotFoundException e) {
             validationContext.errors().add(

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.companieshouse.pscverificationapi.validator;
+
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+
+@Component
+public class PscIdProvidedValidator extends BaseVerificationValidator implements
+    VerificationValidator {
+
+    public PscIdProvidedValidator(final Map<String, String> validation) {
+        super(validation);
+    }
+
+    /**
+     * Validates if a PSC ID is provided in the request.
+     *
+     * @param validationContext the validation context
+     */
+    @Override
+    public void validate(final VerificationValidationContext validationContext) {
+
+        if (Optional.ofNullable(validationContext.dto().pscAppointmentId()).isEmpty()) {
+            validationContext.errors()
+                .add(new FieldError("object", "psc_appointment_id", null,
+                    false, new String[]{null, "psc_appointment_id"}, null,
+                    validation.get("psc-appointment-id-missing")));
+        }
+
+        super.validate(validationContext);
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidator.java
@@ -26,9 +26,9 @@ public class PscIdProvidedValidator extends BaseVerificationValidator implements
                 .add(new FieldError("object", "psc_appointment_id", null,
                     false, new String[]{null, "psc_appointment_id"}, null,
                     validation.get("psc-appointment-id-missing")));
+        }else {
+            super.validate(validationContext);
         }
-
-        super.validate(validationContext);
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/config/ValidatorConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/config/ValidatorConfigTest.java
@@ -2,10 +2,8 @@ package uk.gov.companieshouse.pscverificationapi.config;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.validator.PscExistsValidator;
+import uk.gov.companieshouse.pscverificationapi.validator.PscIdProvidedValidator;
 import uk.gov.companieshouse.pscverificationapi.validator.PscIsActiveValidator;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,6 +20,8 @@ class ValidatorConfigTest {
 
     private ValidatorConfig testConfig;
 
+    @Mock
+    PscIdProvidedValidator pscIdProvidedValidator;
     @Mock
     private PscExistsValidator pscExistsValidator;
     @Mock
@@ -33,10 +34,10 @@ class ValidatorConfigTest {
 
     @Test
     void verificationValidationEnable() {
-        final var valid = testConfig.verificationValidationEnable( pscExistsValidator, pscIsActiveValidator);
+        final var valid = testConfig.verificationValidationEnable(pscIdProvidedValidator, pscExistsValidator, pscIsActiveValidator);
 
         assertThat(valid.pscType(), is(PscType.INDIVIDUAL));
-        assertThat(valid.first(), is(pscExistsValidator));
+        assertThat(valid.first(), is(pscIdProvidedValidator));
         verify(pscExistsValidator, times(1)).setNext(pscIsActiveValidator);
     }
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidatorTest.java
@@ -1,0 +1,94 @@
+package uk.gov.companieshouse.pscverificationapi.validator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.FieldError;
+import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
+import uk.gov.companieshouse.api.model.pscverification.RelevantOfficer;
+import uk.gov.companieshouse.api.model.pscverification.VerificationDetails;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
+
+@ExtendWith(MockitoExtension.class)
+class PscIdProvidedValidatorTest {
+
+    @Mock
+    private RelevantOfficer relevantOfficer;
+    @Mock
+    VerificationDetails verificationDetails;
+    @Mock
+    private Map<String, String> validation;
+    @Mock
+    private Transaction transaction;
+
+    PscIdProvidedValidator testValidator;
+    private PscType pscType;
+    private List<FieldError> errors;
+    private String passthroughHeader;
+    private PscVerificationData pscVerificationData;
+
+    private static final String PSC_ID = "67edfE436y35hetsie6zuAZtr";
+
+    @BeforeEach
+    void setUp() {
+
+        errors = new ArrayList<>();
+        pscType = PscType.INDIVIDUAL;
+        passthroughHeader = "passthroughHeader";
+
+        testValidator = new PscIdProvidedValidator(validation);
+    }
+
+    @AfterEach
+    void tearDown() {
+        pscVerificationData = null;
+    }
+
+    @Test
+    void validateWhenPscIdProvided() {
+        pscVerificationData = new PscVerificationData(
+            "12345678",
+            PSC_ID,
+            relevantOfficer,
+            verificationDetails
+        );
+
+        testValidator.validate(
+            new VerificationValidationContext(pscVerificationData, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void validateWhenPscIdNotProvided() {
+        var fieldError = new FieldError("object", "psc_appointment_id", null, false,
+            new String[]{null, "psc_appointment_id"}, null,
+            "not-provided default message");
+
+        pscVerificationData = mock(PscVerificationData.class);
+
+        when(pscVerificationData.pscAppointmentId()).thenReturn(null);
+        when(validation.get("psc-appointment-id-missing")).thenReturn("not-provided default message");
+
+        testValidator.validate(
+            new VerificationValidationContext(pscVerificationData, errors, transaction, pscType, passthroughHeader));
+
+        assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
+        assertThat(errors, contains(fieldError));
+    }
+}


### PR DESCRIPTION
IDVA3-557
Add new validator: PscIdProvidedValidator
Add new unit tests
Add new validation to ValidatorConfig
Update validation chain so that PscIdProvidedValidator runs first