### PR TITLE
IDVA3-2240: Get the UVID PSC name data 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,12 @@
         <equalsverifier.version>3.15.1</equalsverifier.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
         <!--- CH -->
-        <structured-logging.version>3.0.1</structured-logging.version>
+        <structured-logging.version>3.0.15</structured-logging.version>
         <api-security-java.version>2.0.7</api-security-java.version>
-        <api-helper-java.version>3.0.0</api-helper-java.version>
-        <api-sdk-java.version>6.0.13</api-sdk-java.version>
+        <api-helper-java.version>3.0.1</api-helper-java.version>
+        <api-sdk-java.version>6.0.20</api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
+        <private-api-sdk-java.version>4.0.207</private-api-sdk-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
@@ -100,6 +101,11 @@
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>private-api-sdk-java</artifactId>
+            <version>${private-api-sdk-java.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/service/PscLookupService.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/service/PscLookupService.java
@@ -26,7 +26,7 @@ public interface PscLookupService {
 
 
     /**
-     * Retrieve a UvidMatch by PscVerificationData.
+     * Retrieve a UvidMatch with the PSC data.
      *
      * @param transaction       the Transaction
      * @param data              the PSC verification data
@@ -35,7 +35,7 @@ public interface PscLookupService {
      * @return the UvidMatch, if found
      * @throws PscLookupServiceException if the PSC was not found or an error occurred
      */
-    UvidMatch getUvidMatchFromPscData(Transaction transaction, PscVerificationData data, PscType pscType, final String ericPassThroughHeader)
+    UvidMatch getUvidMatchWithPscData(Transaction transaction, PscVerificationData data, PscType pscType, final String ericPassThroughHeader)
         throws PscLookupServiceException;
 
 }

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/service/PscLookupService.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/service/PscLookupService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.pscverificationapi.service;
 
+import uk.gov.companieshouse.api.identityverification.model.UvidMatch;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -11,10 +12,10 @@ import uk.gov.companieshouse.pscverificationapi.exception.PscLookupServiceExcept
  */
 public interface PscLookupService {
     /**
-     * Retrieve a PSC by ID.
+     * Retrieve a PSC by PscVerificationData.
      *
      * @param transaction       the Transaction
-     * @param data              the psc verification data
+     * @param data              the PSC verification data
      * @param pscType           the PSC Type
      * @param ericPassThroughHeader includes authorisation for transaction fetch
      * @return the PSC details, if found
@@ -22,4 +23,19 @@ public interface PscLookupService {
      */
     PscApi getPsc(Transaction transaction, PscVerificationData data, PscType pscType, final String ericPassThroughHeader)
         throws PscLookupServiceException;
+
+
+    /**
+     * Retrieve a UvidMatch by PscVerificationData.
+     *
+     * @param transaction       the Transaction
+     * @param data              the PSC verification data
+     * @param pscType           the PSC Type
+     * @param ericPassThroughHeader includes authorisation for transaction fetch
+     * @return the UvidMatch, if found
+     * @throws PscLookupServiceException if the PSC was not found or an error occurred
+     */
+    UvidMatch getUvidMatchFromPscData(Transaction transaction, PscVerificationData data, PscType pscType, final String ericPassThroughHeader)
+        throws PscLookupServiceException;
+
 }

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/service/impl/PscLookupServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/service/impl/PscLookupServiceImpl.java
@@ -2,10 +2,15 @@ package uk.gov.companieshouse.pscverificationapi.service.impl;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.identityverification.model.UvidMatch;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
@@ -15,6 +20,7 @@ import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.exception.FilingResourceNotFoundException;
 import uk.gov.companieshouse.pscverificationapi.exception.PscLookupServiceException;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
+import uk.gov.companieshouse.pscverificationapi.utils.LogHelper;
 
 @Service
 public class PscLookupServiceImpl implements PscLookupService {
@@ -28,11 +34,22 @@ public class PscLookupServiceImpl implements PscLookupService {
         this.logger = logger;
     }
 
+    /**
+     * Retrieve a PSC by PscVerificationData.
+     *
+     * @param transaction       the Transaction
+     * @param data              the PSC verification data
+     * @param pscType           the PSC Type
+     * @param ericPassThroughHeader includes authorisation for transaction fetch
+     * @return the PSC details, if found
+     * @throws PscLookupServiceException if the PSC was not found or an error occurred
+     */
     @Override
     public PscApi getPsc(final Transaction transaction, final PscVerificationData data,
                                          final PscType pscType, final String ericPassThroughHeader)
         throws PscLookupServiceException {
 
+        final var logMap = LogHelper.createLogMap(transaction.getId());
         String pscAppointmentId = data.pscAppointmentId();
 
         try {
@@ -51,6 +68,7 @@ public class PscLookupServiceImpl implements PscLookupService {
 
         } catch (final ApiErrorResponseException e) {
             if (e.getStatusCode() == HttpStatus.NOT_FOUND.value()) {
+                logger.errorContext(transaction.getId(), UNEXPECTED_STATUS_CODE, e, logMap);
                 throw new FilingResourceNotFoundException(
                     MessageFormat.format("PSC Details not found for {0}: {1} {2}", pscAppointmentId,
                         e.getStatusCode(), e.getStatusMessage()), e);
@@ -60,9 +78,50 @@ public class PscLookupServiceImpl implements PscLookupService {
                     e.getStatusCode(), e.getStatusMessage()), e);
 
         } catch (URIValidationException | IOException e) {
+            logger.errorContext(transaction.getId(), UNEXPECTED_STATUS_CODE, e, logMap);
             throw new PscLookupServiceException(
                 MessageFormat.format("Error Retrieving PSC details for {0}: {1}", pscAppointmentId,
                     e.getMessage()), e);
         }
+    }
+
+    /**
+     * Retrieve a UvidMatch by PscVerificationData.
+     *
+     * @param transaction       the Transaction
+     * @param data              the PSC verification data
+     * @param pscType           the PSC Type
+     * @param ericPassThroughHeader includes authorisation for transaction fetch
+     * @return the UvidMatch, if found
+     * @throws PscLookupServiceException if the PSC was not found or an error occurred
+     */
+    @Override
+    public UvidMatch getUvidMatchFromPscData(final Transaction transaction,
+        final PscVerificationData data, final PscType pscType, final String ericPassThroughHeader)
+        throws PscLookupServiceException {
+
+        PscApi pscData = getPsc(transaction, data, pscType, ericPassThroughHeader);
+        UvidMatch uvidMatch;
+        uvidMatch = getUvidMatch(pscData);
+
+        return uvidMatch;
+    }
+
+    //TODO Update UvidMatch with the full DOB when available from the PscDetails
+    private UvidMatch getUvidMatch(PscApi pscData) {
+        UvidMatch uvidMatch = new UvidMatch();
+
+        List<String> forenames = new ArrayList<>();
+        Optional<String> forename = Optional.ofNullable(pscData.getNameElements().getForename());
+        Optional<String> otherForenames = Optional.ofNullable(pscData.getNameElements().getOtherForenames());
+        Optional<String> surname = Optional.ofNullable(pscData.getNameElements().getSurname());
+
+        forename.ifPresent(forenames::add);
+        otherForenames.ifPresent(names -> forenames.addAll(Arrays.asList(names.split("\\s+"))));
+
+        uvidMatch.setForenames(forenames);
+        uvidMatch.setSurname(surname.orElse(""));
+
+        return uvidMatch;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/PscLookupServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/PscLookupServiceImplTest.java
@@ -1,0 +1,304 @@
+package uk.gov.companieshouse.pscverificationapi.service.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.pscverificationapi.enumerations.PscType.INDIVIDUAL;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.psc.PscsResourceHandler;
+import uk.gov.companieshouse.api.handler.psc.request.PscIndividualGet;
+import uk.gov.companieshouse.api.identityverification.model.UvidMatch;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.psc.NameElementsApi;
+import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
+import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.sdk.ApiClientService;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
+import uk.gov.companieshouse.pscverificationapi.exception.FilingResourceNotFoundException;
+import uk.gov.companieshouse.pscverificationapi.exception.PscLookupServiceException;
+import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
+
+@ExtendWith(MockitoExtension.class)
+class PscLookupServiceImplTest extends TestBaseService {
+
+    private static final String PSC_ID = "654321";
+    private static final PscVerificationData PSC_VERIFICATION_DATA =
+        PscVerificationData.newBuilder().pscAppointmentId(PSC_ID).companyNumber(COMPANY_NUMBER)
+            .build();
+
+    @Mock
+    private ApiClientService apiClientService;
+    @Mock
+    private ApiClient apiClient;
+    @Mock
+    private ApiResponse<PscApi> apiResponse;
+    @Mock
+    private PscIndividualGet pscIndividualGet;
+    @Mock
+    private PscsResourceHandler pscsResourceHandler;
+    @Mock
+    private Transaction transaction;
+    @Mock
+    private Logger logger;
+    private PscLookupService testService;
+
+    @BeforeAll
+    public static void setUpForClass() {
+        PscType[] newEnumValues = addNewEnumValue();
+        myMockedEnum = mockStatic(PscType.class);
+        myMockedEnum.when(PscType::values).thenReturn(newEnumValues);
+        mockedValue = newEnumValues[newEnumValues.length - 1];
+        when(mockedValue.name()).thenReturn("UNKNOWN");
+    }
+
+    @AfterAll
+    public static void tearDownForClass() {
+        myMockedEnum.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        testService = new PscLookupServiceImpl(apiClientService, logger);
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @Test
+    void getPscIndividualWhenFound() throws IOException, URIValidationException {
+        when(apiResponse.getData()).thenReturn(new PscApi());
+        when(pscIndividualGet.execute()).thenReturn(apiResponse);
+        when(pscsResourceHandler.getIndividual("/company/"
+            + COMPANY_NUMBER
+            + "/persons-with-significant-control/"
+            + INDIVIDUAL.getValue()
+            + "/"
+            + PSC_ID)).thenReturn(pscIndividualGet);
+        when(apiClient.pscs()).thenReturn(pscsResourceHandler);
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+
+        var pscApi =
+            testService.getPsc(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL, PASSTHROUGH_HEADER);
+
+        assertThat(pscApi, samePropertyValuesAs(new PscApi()));
+
+    }
+
+    @Test
+    void getPscWhenIoException() throws IOException {
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenThrow(
+            new IOException("get test case"));
+
+        final var thrown = assertThrows(PscLookupServiceException.class,
+            () -> testService.getPsc(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL,
+                PASSTHROUGH_HEADER));
+        assertThat(thrown.getMessage(),
+            is("Error Retrieving PSC details for " + PSC_ID + ": get test case"));
+    }
+
+    @Test
+    void getPscWhenNotFound() throws IOException {
+        final var exception = new ApiErrorResponseException(
+            new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "test case",
+                new HttpHeaders()));
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenThrow(exception);
+
+        final var thrown = assertThrows(FilingResourceNotFoundException.class,
+            () -> testService.getPsc(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL,
+                PASSTHROUGH_HEADER));
+
+        assertThat(thrown.getMessage(),
+            is("PSC Details not found for " + PSC_ID + ": 404 test case"));
+    }
+
+    @Test
+    void getPscWhenErrorRetrieving() throws IOException {
+        final var exception = new ApiErrorResponseException(
+            new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_FORBIDDEN, "test case",
+                new HttpHeaders()));
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenThrow(exception);
+
+        final var thrown = assertThrows(PscLookupServiceException.class,
+            () -> testService.getPsc(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL,
+                PASSTHROUGH_HEADER));
+
+        assertThat(thrown.getMessage(),
+            is("Error Retrieving PSC details for " + PSC_ID + ": 403 test case"));
+    }
+
+    //TODO - Add if it is agreed to implement RO verifications
+    @Disabled
+    @Test
+    void getPscWhenTypeNotRecognised() {
+
+        final var thrown = assertThrows(UnsupportedOperationException.class,
+            () -> testService.getPsc(transaction, PSC_VERIFICATION_DATA, mockedValue,
+                PASSTHROUGH_HEADER));
+
+        assertThat(thrown.getMessage(), is("PSC type UNKNOWN not supported for PSC ID " + PSC_ID));
+    }
+
+    @Test
+    void getUvidMatchFromPscDataWhenFound() throws IOException, URIValidationException {
+
+        UvidMatch uvidMatch = new UvidMatch();
+        List<String> forenames =
+            new ArrayList<>(Arrays.asList("Forename1", "Forename2", "Forename3"));
+        uvidMatch.setForenames(forenames);
+        uvidMatch.setSurname("Surname");
+
+        PscApi pscData = new PscApi();
+        NameElementsApi nameElements = new NameElementsApi();
+        nameElements.setForename("Forename1");
+        nameElements.setOtherForenames("Forename2 Forename3");
+        nameElements.setSurname("Surname");
+        pscData.setNameElements(nameElements);
+
+        when(apiResponse.getData()).thenReturn(pscData);
+        when(pscIndividualGet.execute()).thenReturn(apiResponse);
+        when(pscsResourceHandler.getIndividual("/company/"
+            + COMPANY_NUMBER
+            + "/persons-with-significant-control/"
+            + INDIVIDUAL.getValue()
+            + "/"
+            + PSC_ID)).thenReturn(pscIndividualGet);
+        when(apiClient.pscs()).thenReturn(pscsResourceHandler);
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+
+        var uvidMatchTest =
+            testService.getUvidMatchFromPscData(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL,
+                PASSTHROUGH_HEADER);
+
+        assertThat(uvidMatchTest, samePropertyValuesAs(uvidMatch));
+
+    }
+
+    @Test
+    void getUvidMatchFromPscDataWhenForenamesBlank() throws IOException, URIValidationException {
+
+        UvidMatch uvidMatch = new UvidMatch();
+        List<String> forenames = new ArrayList<>(List.of());
+        uvidMatch.setForenames(forenames);
+        uvidMatch.setSurname("Surname");
+
+        PscApi pscData = new PscApi();
+        NameElementsApi nameElements = new NameElementsApi();
+        nameElements.setSurname("Surname");
+        pscData.setNameElements(nameElements);
+
+        when(apiResponse.getData()).thenReturn(pscData);
+        when(pscIndividualGet.execute()).thenReturn(apiResponse);
+        when(pscsResourceHandler.getIndividual("/company/"
+            + COMPANY_NUMBER
+            + "/persons-with-significant-control/"
+            + INDIVIDUAL.getValue()
+            + "/"
+            + PSC_ID)).thenReturn(pscIndividualGet);
+        when(apiClient.pscs()).thenReturn(pscsResourceHandler);
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+
+        var uvidMatchTest =
+            testService.getUvidMatchFromPscData(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL,
+                PASSTHROUGH_HEADER);
+
+        assertThat(uvidMatchTest, samePropertyValuesAs(uvidMatch));
+
+    }
+
+    @Test
+    void getUvidMatchWhenSurnameBlank() throws IOException, URIValidationException {
+
+        UvidMatch uvidMatch = new UvidMatch();
+        List<String> forenames =
+            new ArrayList<>(Arrays.asList("Forename1", "Forename2", "Forename3"));
+        uvidMatch.setForenames(forenames);
+        uvidMatch.setSurname("");
+
+        PscApi pscData = new PscApi();
+        NameElementsApi nameElements = new NameElementsApi();
+        nameElements.setForename("Forename1");
+        nameElements.setOtherForenames("Forename2 Forename3");
+        pscData.setNameElements(nameElements);
+
+        when(apiResponse.getData()).thenReturn(pscData);
+        when(pscIndividualGet.execute()).thenReturn(apiResponse);
+        when(pscsResourceHandler.getIndividual("/company/"
+            + COMPANY_NUMBER
+            + "/persons-with-significant-control/"
+            + INDIVIDUAL.getValue()
+            + "/"
+            + PSC_ID)).thenReturn(pscIndividualGet);
+        when(apiClient.pscs()).thenReturn(pscsResourceHandler);
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenReturn(apiClient);
+
+        var uvidMatchTest =
+            testService.getUvidMatchFromPscData(transaction, PSC_VERIFICATION_DATA, INDIVIDUAL,
+                PASSTHROUGH_HEADER);
+
+        assertThat(uvidMatchTest, samePropertyValuesAs(uvidMatch));
+
+    }
+
+    @Test
+    void getUvidMatchFromPscDataWhenNotFound() throws IOException {
+
+        final var exception = new ApiErrorResponseException(
+            new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "test case",
+                new HttpHeaders()));
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenThrow(exception);
+
+        final var thrown = assertThrows(FilingResourceNotFoundException.class,
+            () -> testService.getUvidMatchFromPscData(transaction, PSC_VERIFICATION_DATA,
+                INDIVIDUAL, PASSTHROUGH_HEADER));
+
+        assertThat(thrown.getMessage(),
+            is("PSC Details not found for " + PSC_ID + ": 404 test case"));
+
+    }
+
+    @Test
+    void getUvidMatchWhenErrorRetrieving() throws IOException {
+        final var exception = new ApiErrorResponseException(
+            new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_FORBIDDEN, "test case",
+                new HttpHeaders()));
+        when(apiClientService.getApiClient(PASSTHROUGH_HEADER)).thenThrow(exception);
+
+        final var thrown = assertThrows(PscLookupServiceException.class,
+            () -> testService.getUvidMatchFromPscData(transaction, PSC_VERIFICATION_DATA,
+                INDIVIDUAL, PASSTHROUGH_HEADER));
+
+        assertThat(thrown.getMessage(),
+            is("Error Retrieving PSC details for " + PSC_ID + ": 403 test case"));
+    }
+
+    @Disabled
+    @Test
+    void getUvidMatchFromPscDataWhenTypeNotRecognised() {
+        //TODO - Add if it is agreed to implement RO verifications
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/TestBaseService.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/TestBaseService.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.pscverificationapi.service.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Array;
+import java.util.EnumSet;
+import org.mockito.MockedStatic;
+import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
+
+public class TestBaseService {
+
+    static final String PASSTHROUGH_HEADER = "passthrough";
+    static final String TRANS_ID = "23445657412";
+    static final String COMPANY_NUMBER = "12345678";
+    static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
+    static PscType mockedValue;
+    static MockedStatic<PscType> myMockedEnum;
+    static Class<PscType> enumPscType = PscType.class;
+
+    //Use to mock out the PscType enum class
+    @SuppressWarnings("unchecked")
+    static <PscType extends Enum<PscType>> PscType[] addNewEnumValue() {
+        final EnumSet<PscType> enumSet = EnumSet.allOf((Class<PscType>) enumPscType);
+        final PscType[] newValues = (PscType[]) Array.newInstance(enumPscType, enumSet.size() + 1);
+        int i = 0;
+        for (final PscType value : enumSet) {
+            newValues[i] = value;
+            i++;
+        }
+
+        final PscType newEnumValue = mock((Class<PscType>) enumPscType);
+        newValues[newValues.length - 1] = newEnumValue;
+
+        when(newEnumValue.ordinal()).thenReturn(newValues.length - 1);
+
+        return newValues;
+    }
+}


### PR DESCRIPTION
### Add business logic to retrieve the PSC name data for a UVID

- Add a new method to the `PscLookupService` to retrieve a `UvidMatch` instance with the PSC name data
- Business logic is to retrieve the fields `forename`, `middleName `and `surname` from the PSC data where the `middleName` may contain multiple names, and the `otherForenames` is not used, as it not populated
- Add a new test class with tests for the new and existing business logic in `PscLookupServiceImpl`
- Updates to POM to enable access to the the identity-verification-api and its `UvidMatch` class
- Minor updates to Javadoc and logging