### PR TITLE
Add call to PscLookupService to getPscIndividualFullRecord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <api-sdk-java.version>6.0.20</api-sdk-java.version>
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.241</private-api-sdk-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <api-sdk-java.version>6.0.20</api-sdk-java.version>
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>4.0.207</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/service/PscLookupService.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/service/PscLookupService.java
@@ -4,6 +4,7 @@ import uk.gov.companieshouse.api.identityverification.model.UvidMatch;
 import uk.gov.companieshouse.api.model.psc.PscApi;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.api.psc.IndividualFullRecord;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.exception.PscLookupServiceException;
 
@@ -24,6 +25,17 @@ public interface PscLookupService {
     PscApi getPsc(Transaction transaction, PscVerificationData data, PscType pscType, final String ericPassThroughHeader)
         throws PscLookupServiceException;
 
+    /**
+     * Retrieve a PSC Individual Full Record by PscVerificationData.
+     *
+     * @param transaction           the Transaction
+     * @param data                  the PSC verification data
+     * @param pscType               the PSC Type
+     * @return the PSC Full Record details, if found
+     * @throws PscLookupServiceException if the PSC was not found or an error occurred
+     */
+    IndividualFullRecord getPscIndividualFullRecord(Transaction transaction, PscVerificationData data, PscType pscType)
+            throws PscLookupServiceException;
 
     /**
      * Retrieve a UvidMatch with the PSC data.

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/PscLookupServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/PscLookupServiceImplTest.java
@@ -43,6 +43,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.exception.FilingResourceNotFoundException;
 import uk.gov.companieshouse.pscverificationapi.exception.PscLookupServiceException;
+import uk.gov.companieshouse.pscverificationapi.sdk.companieshouse.InternalApiClientService;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +68,8 @@ class PscLookupServiceImplTest extends TestBaseService {
 
     @Mock
     private ApiClientService apiClientService;
+    @Mock
+    private InternalApiClientService internalApiClientService;
     @Mock
     private ApiClient apiClient;
     @Mock
@@ -97,7 +100,7 @@ class PscLookupServiceImplTest extends TestBaseService {
 
     @BeforeEach
     void setUp() {
-        testService = new PscLookupServiceImpl(apiClientService, logger);
+        testService = new PscLookupServiceImpl(apiClientService, internalApiClientService, logger);
     }
 
     @AfterEach


### PR DESCRIPTION
This is a replacement for `getPsc` and would be called by ` pscLookupService.getPscIndividualFullRecord` in `validator/PscExistsValidator`

IDVA3-2394