### PR TITLE
Update UvidExistsValidator and verification patch operation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <structured-logging.version>3.0.15</structured-logging.version>
         <api-security-java.version>2.0.7</api-security-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-sdk-java.version>6.0.20</api-sdk-java.version>
+        <api-sdk-java.version>6.0.22</api-sdk-java.version>
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>4.0.207</private-api-sdk-java.version>

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/ValidationStatusControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/ValidationStatusControllerImpl.java
@@ -1,7 +1,8 @@
 package uk.gov.companieshouse.pscverificationapi.controller.impl;
 
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
+import java.util.HashSet;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -93,7 +94,7 @@ public class ValidationStatusControllerImpl implements ValidationStatusControlle
     private ValidationStatusError[] calculateIsValid(final PscVerification pscVerification,
                                                      final String passthroughHeader, final Transaction transaction) {
 
-        final var errors = new ArrayList<FieldError>();
+        final var errors = new HashSet<FieldError>();
 
         VerificationValidationContext context = new VerificationValidationContext(
             pscVerification.getData(), errors, transaction, PscType.INDIVIDUAL, passthroughHeader);

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/mapper/ErrorMapper.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/mapper/ErrorMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.pscverificationapi.mapper;
 
-import java.util.List;
+import java.util.Set;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.validation.FieldError;
@@ -16,5 +17,5 @@ public interface ErrorMapper {
     @Mapping(target="locationType", expression = "java(LocationType.JSON_PATH.getValue())")
     ValidationStatusError map(final FieldError fieldError);
 
-    ValidationStatusError[] map(final List<FieldError> fieldErrors);
+    ValidationStatusError[] map(final Set<FieldError> fieldErrors);
 }

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidator.java
@@ -1,8 +1,5 @@
 package uk.gov.companieshouse.pscverificationapi.validator;
 
-import java.text.MessageFormat;
-import java.util.List;
-import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -14,11 +11,13 @@ import uk.gov.companieshouse.pscverificationapi.exception.IdvLookupServiceExcept
 import uk.gov.companieshouse.pscverificationapi.service.IdvLookupService;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
+
 @Component
 public class UvidExistsValidator extends BaseVerificationValidator implements
     VerificationValidator {
-
-    public static final String DETAILS_MATCH_UVID = "details_match_uvid";
 
     private final IdvLookupService idvLookupService;
     private final PscLookupService pscLookupService;
@@ -50,18 +49,27 @@ public class UvidExistsValidator extends BaseVerificationValidator implements
         }
 
         List<UvidMatchResponse.AccuracyStatementEnum> accuracyStatementList = uvidMatchResponse.getAccuracyStatement();
-        for (UvidMatchResponse.AccuracyStatementEnum accuracyStatement : accuracyStatementList) {
 
-            if (accuracyStatement.getValue().equals(DETAILS_MATCH_UVID)) {
-                break;
-            }
-            validationContext.errors().add(
-                new FieldError("object", "uvid_match", dto.verificationDetails().uvid(), false,
-                    new String[]{null, dto.verificationDetails().uvid()}, null,
-                    validation.get(snakeToKebab(accuracyStatement.getValue()))));
+        if (!accuracyStatementList.contains(UvidMatchResponse.AccuracyStatementEnum.DETAILS_MATCH_UVID)) {
+            checkForValidationErrors(accuracyStatementList, dto, validationContext);
         }
 
         super.validate(validationContext);
+    }
+
+    public void checkForValidationErrors(List<UvidMatchResponse.AccuracyStatementEnum> accuracyStatementList,
+                                        PscVerificationData dto, VerificationValidationContext validationContext) {
+
+        for (UvidMatchResponse.AccuracyStatementEnum accuracyStatement : accuracyStatementList) {
+            String accuracyStatementValue = switch (accuracyStatement.getValue()){
+                case "forenames_mismatch", "surname_mismatch" -> "no-name-mismatch-reason";
+                default -> accuracyStatement.getValue();
+            };
+            validationContext.errors().add(
+                new FieldError("object", "uvid_match", dto.verificationDetails().uvid(), false,
+                    new String[]{null, dto.verificationDetails().uvid()}, null,
+                    validation.get(snakeToKebab(accuracyStatementValue))));
+        }
     }
 
     private String snakeToKebab(String str) {

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/VerificationValidationContext.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/VerificationValidationContext.java
@@ -6,34 +6,15 @@ import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.StringJoiner;
 
 public record VerificationValidationContext(@NonNull PscVerificationData dto,
-                                            @NonNull List<FieldError> errors,
+                                            @NonNull Set<FieldError> errors,
                                             @NonNull Transaction transaction,
                                             @NonNull PscType pscType,
                                             String passthroughHeader) {
-
-
-
-    /**
-     * @param dto               the DTO to validate
-     * @param errors            the list of errors append; MUST be non-null and modifiable
-     * @param transaction       the Transaction
-     * @param pscType           the PSC type
-     * @param passthroughHeader the request pass through header
-     */
-    public VerificationValidationContext(@NonNull final PscVerificationData dto,
-        @NonNull final List<FieldError> errors, @NonNull final Transaction transaction,
-        @NonNull final PscType pscType, final String passthroughHeader) {
-        this.dto = dto;
-        this.errors = errors;
-        this.transaction = transaction;
-        this.pscType = pscType;
-        this.passthroughHeader = passthroughHeader;
-    }
 
     @Override
     public boolean equals(final Object o) {

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
@@ -66,9 +66,6 @@ class PscVerificationControllerImplTest {
     private static final URI REQUEST_URI = URI.create(
         "/transactions/" + TRANS_ID + "/persons-with-significant-control-verification");
 
-    private static final URI SELF_URI = URI.create(REQUEST_URI + FILING_ID);
-    private static final URI VALIDATION_URI = URI.create(
-            SELF_URI + "/validation_status");
     private static final LocalDate TEST_DATE = LocalDate.of(2024, 5, 5);
 
     private PscVerificationController testController;

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
@@ -18,12 +18,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,6 +94,7 @@ class PscVerificationControllerImplTest {
     private PscVerificationData filing;
     private PscVerification entity;
     private PscVerification entityWithLinks;
+    private Map<String, Object> mergePatch;
 
     public static Stream<Arguments> provideCreateParams() {
         return Stream.of(Arguments.of(false, false, false), Arguments.of(true, true, true));
@@ -129,6 +125,9 @@ class PscVerificationControllerImplTest {
                 .data(filing).links(links)
                 .build();
         entityWithLinks = PscVerification.newBuilder(entity).links(links).build();
+        var mergeVerificationDetails = new HashMap<>(Map.of());
+        mergePatch = new HashMap<>();
+        mergePatch.put("verification_details", mergeVerificationDetails);
     }
 
     @ParameterizedTest(
@@ -188,7 +187,163 @@ class PscVerificationControllerImplTest {
         when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
 
         final var response = testController.updatePscVerification(TRANS_ID, FILING_ID,
-            Collections.emptyMap(), request);
+            mergePatch, request);
+        final var expectedBody = filingMapper.toApi(updatedEntity);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(notNullValue()));
+        assertThat(response.getBody(), is(expectedBody));
+        assertThat(response.getBody().getUpdatedAt(),
+            is(not(equalTo(response.getBody().getCreatedAt()))));
+        assertThat(response.getHeaders().getLocation(), is(entityWithLinks.getLinks().self()));
+
+    }
+
+    @Test
+    void updatePscVerificationNoUvid() {
+
+        final var success = new PatchResult();
+        final var updatedEntity = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        VerificationDetails verificationNoUvid = VerificationDetails.newBuilder()
+            .statements(EnumSet.of(VerificationStatementConstants.INDIVIDUAL_VERIFIED))
+            .build();
+        entityWithLinks = PscVerification.newBuilder(entityWithLinks)
+            .data(PscVerificationData.newBuilder(filing).verificationDetails(verificationNoUvid).build())
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks))
+            .thenReturn(Optional.of(updatedEntity));
+
+        when(
+            pscVerificationService.requestMatchesResourceSelf(request, entityWithLinks)).thenReturn(
+            true);
+        when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
+
+        final var response = testController.updatePscVerification(TRANS_ID, FILING_ID,
+            mergePatch, request);
+        final var expectedBody = filingMapper.toApi(updatedEntity);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(notNullValue()));
+        assertThat(response.getBody(), is(expectedBody));
+        assertThat(response.getBody().getUpdatedAt(),
+            is(not(equalTo(response.getBody().getCreatedAt()))));
+        assertThat(response.getHeaders().getLocation(), is(entityWithLinks.getLinks().self()));
+
+    }
+
+    @Test
+    void updatePscVerificationPatchUvidMatch() {
+
+        final var success = new PatchResult();
+
+        var mergeVerificationDetails = new HashMap<>(Map.of());
+        mergeVerificationDetails.put("uvid", UVID);
+        mergePatch.clear();
+        mergePatch.put("verification_details", mergeVerificationDetails);
+
+
+        final var updatedEntity = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        entityWithLinks = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks))
+            .thenReturn(Optional.of(updatedEntity));
+
+        when(
+            pscVerificationService.requestMatchesResourceSelf(request, entityWithLinks)).thenReturn(
+            true);
+        when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
+
+        final var response = testController.updatePscVerification(TRANS_ID, FILING_ID,
+            mergePatch, request);
+        final var expectedBody = filingMapper.toApi(updatedEntity);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(notNullValue()));
+        assertThat(response.getBody(), is(expectedBody));
+        assertThat(response.getBody().getUpdatedAt(),
+            is(not(equalTo(response.getBody().getCreatedAt()))));
+        assertThat(response.getHeaders().getLocation(), is(entityWithLinks.getLinks().self()));
+
+    }
+
+    @Test
+    void updatePscVerificationNoNameMismatchPatch() {
+
+        final var success = new PatchResult();
+
+        var mergeVerificationDetails = new HashMap<>(Map.of());
+        mergeVerificationDetails.put("uvid", "12345678");
+        mergePatch.clear();
+        mergePatch.put("verification_details", mergeVerificationDetails);
+
+        final var updatedEntity = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        entityWithLinks = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks))
+            .thenReturn(Optional.of(updatedEntity));
+
+        when(
+            pscVerificationService.requestMatchesResourceSelf(request, entityWithLinks)).thenReturn(
+            true);
+        when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
+
+        final var response = testController.updatePscVerification(TRANS_ID, FILING_ID,
+            mergePatch, request);
+        final var expectedBody = filingMapper.toApi(updatedEntity);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(notNullValue()));
+        assertThat(response.getBody(), is(expectedBody));
+        assertThat(response.getBody().getUpdatedAt(),
+            is(not(equalTo(response.getBody().getCreatedAt()))));
+        assertThat(response.getHeaders().getLocation(), is(entityWithLinks.getLinks().self()));
+
+    }
+
+    @Test
+    void updatePscVerificationNameMismatchPatchPresent() {
+
+        final var success = new PatchResult();
+
+        var mergeVerificationDetails = new HashMap<>(Map.of());
+        mergeVerificationDetails.put("uvid", "12345678");
+        mergeVerificationDetails.put("name_mismatch_reason", "PREFER_NOT_TO_SAY");
+        mergePatch.clear();
+        mergePatch.put("verification_details", mergeVerificationDetails);
+
+        final var updatedEntity = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        entityWithLinks = PscVerification.newBuilder(entityWithLinks)
+            .updatedAt(SECOND_INSTANT)
+            .build();
+
+        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks))
+            .thenReturn(Optional.of(updatedEntity));
+
+        when(
+            pscVerificationService.requestMatchesResourceSelf(request, entityWithLinks)).thenReturn(
+            true);
+        when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
+
+        final var response = testController.updatePscVerification(TRANS_ID, FILING_ID,
+            mergePatch, request);
         final var expectedBody = filingMapper.toApi(updatedEntity);
 
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
@@ -203,7 +358,6 @@ class PscVerificationControllerImplTest {
     @Test
     void updatePscVerificationWhenPatchProviderRetrievalFails() {
         final var failure = new PatchResult(RetrievalFailureReason.FILING_NOT_FOUND);
-        final Map<String, Object> patchMap = Collections.emptyMap();
 
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks));
         when(
@@ -212,7 +366,7 @@ class PscVerificationControllerImplTest {
         when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(failure);
 
         final var exception = assertThrows(FilingResourceNotFoundException.class,
-            () -> testController.updatePscVerification(TRANS_ID, FILING_ID, patchMap, request));
+            () -> testController.updatePscVerification(TRANS_ID, FILING_ID, mergePatch, request));
 
         assertThat(exception.getMessage(), is(FILING_ID));
     }
@@ -224,7 +378,6 @@ class PscVerificationControllerImplTest {
                 "future" + ".date.java.time.LocalDate", "future.date"},
             new Object[]{TEST_DATE}, "bad date");
         final var failure = new PatchResult(List.of(error));
-        final Map<String, Object> patchMap = Collections.emptyMap();
 
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks));
         when(
@@ -233,14 +386,13 @@ class PscVerificationControllerImplTest {
         when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(failure);
 
         final var exception = assertThrows(InvalidPatchException.class,
-            () -> testController.updatePscVerification(TRANS_ID, FILING_ID, patchMap, request));
+            () -> testController.updatePscVerification(TRANS_ID, FILING_ID, mergePatch, request));
 
         assertThat(exception.getFieldErrors(), contains(error));
     }
 
     @Test
     void updatePscVerificationWhenSelfLinkMatchFails() {
-        final Map<String, Object> patchMap = Collections.emptyMap();
 
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks));
         when(
@@ -248,7 +400,7 @@ class PscVerificationControllerImplTest {
             false);
 
         final var exception = assertThrows(FilingResourceNotFoundException.class,
-            () -> testController.updatePscVerification(TRANS_ID, FILING_ID, patchMap, request));
+            () -> testController.updatePscVerification(TRANS_ID, FILING_ID, mergePatch, request));
 
         assertThat(exception.getMessage(), is(FILING_ID));
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/ValidationStatusControllerImplTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.pscverificationapi.controller.impl.ValidationStatusControllerImpl.TRANSACTION_NOT_SUPPORTED_ERROR;
 
@@ -88,7 +88,7 @@ class ValidationStatusControllerImplTest {
         final var filing = PscVerification.newBuilder().links(links).build();
 
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(filing));
-        when(errorMapper.map(anyList())).thenReturn(new ValidationStatusError[0]);
+        when(errorMapper.map(anySet())).thenReturn(new ValidationStatusError[0]);
 
         final var response = testController.validate(TRANS_ID, FILING_ID, transaction, request);
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/ValidationStatusControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/ValidationStatusControllerImplTest.java
@@ -34,8 +34,6 @@ class ValidationStatusControllerImplTest {
     private static final String TRANS_ID = "117524-754816-491724";
     private static final String FILING_ID = "6332aa6ed28ad2333c3a520a";
     private static final String PASSTHROUGH_HEADER = "passthrough";
-    private static final String SELF_FRAGMENT =
-            "/transactions/" + TRANS_ID + "/persons-with-significant-control-verification/";
 
     @Mock
     private PscVerificationService pscVerificationService;

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/CompanyStatusValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/CompanyStatusValidatorTest.java
@@ -14,10 +14,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.service.CompanyProfileService;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,7 +40,7 @@ class CompanyStatusValidatorTest {
 
     CompanyStatusValidator testValidator;
     private PscType pscType;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     private String passthroughHeader;
 
     private static final List<String> companyStatusList = Collections.singletonList("dissolved");
@@ -51,7 +48,7 @@ class CompanyStatusValidatorTest {
     @BeforeEach
     void setUp() {
 
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/CompanyTypeValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/CompanyTypeValidatorTest.java
@@ -14,9 +14,7 @@ import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.service.CompanyProfileService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,7 +40,7 @@ class CompanyTypeValidatorTest {
 
     CompanyTypeValidator testValidator;
     private PscType pscType;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     private String passthroughHeader;
 
     private static final List<String> companyTypeList = new ArrayList<>();
@@ -50,7 +48,7 @@ class CompanyTypeValidatorTest {
     @BeforeEach
     void setUp() {
 
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscExistsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscExistsValidatorTest.java
@@ -7,9 +7,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,7 @@ class PscExistsValidatorTest {
 
     PscExistsValidator testValidator;
     private PscType pscType;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     private String passthroughHeader;
 
     private static final String PSC_ID = "67edfE436y35hetsie6zuAZtr";
@@ -48,7 +47,7 @@ class PscExistsValidatorTest {
     @BeforeEach
     void setUp() {
 
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIdProvidedValidatorTest.java
@@ -8,9 +8,8 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ class PscIdProvidedValidatorTest {
 
     PscIdProvidedValidator testValidator;
     private PscType pscType;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     private String passthroughHeader;
     private PscVerificationData pscVerificationData;
 
@@ -47,7 +46,7 @@ class PscIdProvidedValidatorTest {
     @BeforeEach
     void setUp() {
 
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsActiveValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsActiveValidatorTest.java
@@ -8,9 +8,8 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +41,7 @@ class PscIsActiveValidatorTest {
 
     PscIsActiveValidator testValidator;
     private PscType pscType;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     private String passthroughHeader;
 
     private static final String PSC_ID = "67edfE436y35hetsie6zuAZtr";
@@ -51,7 +50,7 @@ class PscIsActiveValidatorTest {
     @BeforeEach
     void setUp() {
 
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidatorTest.java
@@ -23,10 +23,7 @@ import uk.gov.companieshouse.pscverificationapi.exception.IdvLookupServiceExcept
 import uk.gov.companieshouse.pscverificationapi.service.IdvLookupService;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -35,13 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.DETAILS_MATCH_UVID;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.DOB_MISMATCH;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.EXPIRED_UVID;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.FORENAMES_MISMATCH;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.INVALID_RECORD;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.SURNAME_MISMATCH;
-import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.UNKNOWN_UVID;
+import static uk.gov.companieshouse.api.identityverification.model.UvidMatchResponse.AccuracyStatementEnum.*;
 
 @ExtendWith(MockitoExtension.class)
 class UvidExistsValidatorTest {
@@ -72,15 +63,18 @@ class UvidExistsValidatorTest {
 
     UvidExistsValidator testValidator;
     private PscType pscType;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     private String passthroughHeader;
+    VerificationValidationContext validationContext;
 
     @BeforeEach
     void setUp() {
 
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
+        validationContext = new VerificationValidationContext(pscVerificationData, errors, transaction, pscType, passthroughHeader);
+
 
         testValidator = new UvidExistsValidator(validation, idvLookupService, pscLookupService);
     }
@@ -116,22 +110,21 @@ class UvidExistsValidatorTest {
 
     @ParameterizedTest
     @MethodSource("provideParameters")
-    void validateWhenUvidMatchError(UvidMatchResponse.AccuracyStatementEnum accuracyStatementEnum, String errorValue, String errorText) throws ApiErrorResponseException {
+    void validateWhenUvidMatchError(String errorValue, String errorText, List<UvidMatchResponse.AccuracyStatementEnum> statementEnums) throws ApiErrorResponseException {
 
         when(pscVerificationData.verificationDetails()).thenReturn(verificationDetails);
         when(pscVerificationData.verificationDetails().uvid()).thenReturn(errorValue);
         when(pscLookupService.getUvidMatchWithPscData(transaction, pscVerificationData, pscType, passthroughHeader))
             .thenReturn(uvidMatch);
         when(idvLookupService.matchUvid(uvidMatch)).thenReturn(uvidMatchResponse);
-        when(uvidMatchResponse.getAccuracyStatement()).thenReturn(Collections.singletonList(accuracyStatementEnum));
+        when(uvidMatchResponse.getAccuracyStatement()).thenReturn(statementEnums);
 
         var fieldError = new FieldError("object", "uvid_match", pscVerificationData.verificationDetails().uvid(), false,
             new String[]{null, errorValue}, null, errorText);
 
         when(validation.get(errorValue)).thenReturn(errorText);
 
-        testValidator.validate(
-            new VerificationValidationContext(pscVerificationData, errors, transaction, pscType, passthroughHeader));
+        testValidator.validate(validationContext);
 
         assertThat(errors.stream().findFirst().orElseThrow(), equalTo(fieldError));
         assertThat(errors, contains(fieldError));
@@ -140,13 +133,18 @@ class UvidExistsValidatorTest {
     private static Stream<Arguments> provideParameters() {
 
         return Stream.of(
-            Arguments.of(UNKNOWN_UVID, "unknown-uvid", "UVID is not recognised"),
-            Arguments.of(EXPIRED_UVID, "expired-uvid", "UVID has expired"),
-            Arguments.of(INVALID_RECORD, "invalid-record", "UVID is invalid"),
-            Arguments.of(DOB_MISMATCH, "dob-mismatch", "Date of birth does not match"),
-            Arguments.of(FORENAMES_MISMATCH, "forenames-mismatch",
-                "Forename(s) do not match: a name mismatch reason must be provided"),
-            Arguments.of(SURNAME_MISMATCH, "surname-mismatch",
-                "Surname does not match: a name mismatch reason must be provided"));
+            Arguments.of("unknown-uvid", "UVID is not recognised", List.of(UNKNOWN_UVID)),
+            Arguments.of("expired-uvid", "UVID has expired", List.of(EXPIRED_UVID)),
+            Arguments.of("invalid-record", "UVID is invalid", List.of(INVALID_RECORD)),
+            Arguments.of("dob-mismatch", "Date of birth does not match", List.of(DOB_MISMATCH)),
+            Arguments.of("no-name-mismatch-reason",
+                "The name on the public register is different to the name this PSC used for identity verification:" +
+                    " a name mismatch reason must be provided", List.of(FORENAMES_MISMATCH)),
+            Arguments.of("no-name-mismatch-reason",
+                "The name on the public register is different to the name this PSC used for identity verification:" +
+                    " a name mismatch reason must be provided", List.of(SURNAME_MISMATCH)),
+            Arguments.of("no-name-mismatch-reason",
+                "The name on the public register is different to the name this PSC used for identity verification:" +
+                    " a name mismatch reason must be provided", List.of(FORENAMES_MISMATCH, SURNAME_MISMATCH)));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/VerificationValidationContextTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/VerificationValidationContextTest.java
@@ -3,12 +3,11 @@ package uk.gov.companieshouse.pscverificationapi.validator;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,13 +17,12 @@ import org.springframework.validation.FieldError;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
-import uk.gov.companieshouse.pscverificationapi.model.entity.PscVerification;
 
 @ExtendWith(MockitoExtension.class)
 class VerificationValidationContextTest {
     private static final String PASSTHROUGH_HEADER = "passthrough";
     private VerificationValidationContext testContext;
-    private List<FieldError> errors;
+    private Set<FieldError> errors;
     @Mock
     private PscVerificationData dto;
     @Mock
@@ -33,7 +31,7 @@ class VerificationValidationContextTest {
 
     @BeforeEach
     void setUp() {
-        errors = new ArrayList<>();
+        errors = new HashSet<>();
         testContext = new VerificationValidationContext(dto, errors, transaction, PscType.INDIVIDUAL, PASSTHROUGH_HEADER);
     }
 


### PR DESCRIPTION
PscVerificationController - updatePscVerification has a check for name mismatch reason added.
Uvid validator now returns a single error message if either forename or surname are incorrect.