### PR TITLE
Feature/use dep check suppressions main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ submodules:
 	git submodule init
 	git submodule update
 
-FAIL_BUILD_CVSS_LIMIT ?= 0
-
 .PHONY: test-unit
 test-unit:
 	echo "make test-unit does nothing, use build target instead"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 artifact_name       := psc-verification-api
 version             := unversioned
 
+dependency_check_base_suppressions:=common_suppressions_spring_6.xml
+dependency_check_suppressions_repo_branch:=main
+dependency_check_minimum_cvss := 4
+dependency_check_assembly_analyzer_enabled := false
+dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
+suppressions_file := target/suppressions.xml
+
 .PHONY: clean
 clean:
 	mvn clean
@@ -15,15 +22,6 @@ submodules:
 	git submodule update
 
 FAIL_BUILD_CVSS_LIMIT ?= 0
-
-.PHONY: security-check
-security-check: security-report
-	mvn org.owasp:dependency-check-maven:check -DassemblyAnalyzerEnabled=false -DfailBuildOnCVSS=$(FAIL_BUILD_CVSS_LIMIT)
-
-.PHONY: security-report
-security-report:
-	mvn org.owasp:dependency-check-maven:check -DassemblyAnalyzerEnabled=false
-	mvn sonar:sonar
 
 .PHONY: test-unit
 test-unit:
@@ -74,6 +72,35 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
 
+.PHONY: dependency-check
+dependency-check:
+	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+		suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
+	fi; \
+	if [ ! -d "$${suppressions_home}" ]; then \
+	    suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
+			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
+			if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
+				cd "$${suppressions_home}"; \
+				git checkout $(dependency_check_suppressions_repo_branch); \
+				cd -; \
+			fi; \
+		fi; \
+	fi; \
+	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
+	if [  -f "$${suppressions_path}" ]; then \
+		cp -av "$${suppressions_path}" $(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+	else \
+		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
+		exit 1; \
+	fi
+
 .PHONY: security-check
-security-check:
-	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=11 -DassemblyAnalyzerEnabled=false
+security-check: dependency-check
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,8 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.6</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <version>2.1.11</version>
+        <relativePath/>
     </parent>
     <artifactId>psc-verification-api</artifactId>
     <version>unversioned</version>


### PR DESCRIPTION
Use up-to-date dependency-check settings

[Update parent pom to 2.1.11, use relativePath](https://github.com/companieshouse/psc-verification-api/commit/c76583b74f098c566d27c41f6c0acab5c7a527c8) 
All parent pom references use relativePath, which prevents Maven from
searching locally for the parent pom, forcing it to go to the standard
Maven repositories.
2.1.11 brings in latest correct dependency-check settings.

[Tidy, repoint at dep-check-suppressions/main](https://github.com/companieshouse/psc-verification-api/commit/6ea66cbe9801a6493ca68feba56f262cd394a916) 
The 'dependency-check' target uses a variable
dependency_check_suppressions_repo_branch
which previously pointed to a different branch:
feature/suppressions-for-company-accounts-api
... but that branch has been merged into main and so this variable
should now point to main.
Tidied Makefile for dependency-check consistency.
Made line spacing, ordering, format for dependency-check sections
identical across Makefiles.
Added json to dependency check report formats.

[Remove outdated var FAIL_BUILD_CVSS_LIMIT](https://github.com/companieshouse/psc-verification-api/commit/669b15769593dfa5cf9016cb32ef9890ec6a4e33)
