### PR TITLE
IDVA3-2103:Validate personal code when expired

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidator.java
@@ -69,8 +69,10 @@ public class UvidExistsValidator extends BaseVerificationValidator implements
 
         List<UvidMatchResponse.AccuracyStatementEnum> accuracyStatementList = uvidMatchResponse.getAccuracyStatement();
 
+        // Filter for when the uvid is valid but expired
         if (!accuracyStatementList.equals(VALID_UVID_ACCURACY_STATEMENT)) {
-            checkForValidationErrors(accuracyStatementList, dto, validationContext);
+            checkForValidationErrors(accuracyStatementList.stream().filter(item ->
+                            !item.equals(UvidMatchResponse.AccuracyStatementEnum.DETAILS_MATCH_UVID)).toList(), dto, validationContext);
         }
 
         super.validate(validationContext);

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/UvidExistsValidator.java
@@ -29,10 +29,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ArrayList;
+import java.util.Collections;
 
 @Component
 public class UvidExistsValidator extends BaseVerificationValidator implements
     VerificationValidator {
+
+    private static final List<UvidMatchResponse.AccuracyStatementEnum> VALID_UVID_ACCURACY_STATEMENT =
+            Collections.singletonList(UvidMatchResponse.AccuracyStatementEnum.DETAILS_MATCH_UVID);
 
     private final IdvLookupService idvLookupService;
     private final PscLookupService pscLookupService;
@@ -65,7 +69,7 @@ public class UvidExistsValidator extends BaseVerificationValidator implements
 
         List<UvidMatchResponse.AccuracyStatementEnum> accuracyStatementList = uvidMatchResponse.getAccuracyStatement();
 
-        if (!accuracyStatementList.contains(UvidMatchResponse.AccuracyStatementEnum.DETAILS_MATCH_UVID)) {
+        if (!accuracyStatementList.equals(VALID_UVID_ACCURACY_STATEMENT)) {
             checkForValidationErrors(accuracyStatementList, dto, validationContext);
         }
 


### PR DESCRIPTION
Update to ensure when a UVID successfully matches, but is expired, the validation does not return true
Add new test