### PR TITLE
Retrieve and store Internal Id upon POST of PscVerificationData

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <structured-logging.version>3.0.15</structured-logging.version>
         <api-security-java.version>2.0.7</api-security-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-sdk-java.version>unversioned</api-sdk-java.version>
+        <api-sdk-java.version>6.1.1</api-sdk-java.version>
         <sdk-manager-java.version>3.0.10</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>4.0.241</private-api-sdk-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
         <!-- Spring -->
-        <spring-boot-dependencies.version>3.4.2</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>3.4.3</spring-boot-dependencies.version>
         <!-- Maven -->
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <structured-logging.version>3.0.15</structured-logging.version>
         <api-security-java.version>2.0.7</api-security-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-sdk-java.version>6.0.39</api-sdk-java.version>
+        <api-sdk-java.version>unversioned</api-sdk-java.version>
         <sdk-manager-java.version>3.0.10</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>4.0.241</private-api-sdk-java.version>

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
@@ -102,11 +102,11 @@ public class PscVerificationControllerImpl implements PscVerificationController 
         try {
             pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(requestTransaction, data, PscType.INDIVIDUAL);
         } catch (PscLookupServiceException e) {
-            throw new FilingResourceNotFoundException("PSC Notification Id not found, try again");
+            throw new FilingResourceNotFoundException("PSC Notification Id not found");
         }
 
         if (pscIndividualFullRecordApi.getInternalId() == null) {
-            throw new PscLookupServiceException("We can't find the Internal ID, can you file on paper?", new Exception("Internal Id"));
+            throw new PscLookupServiceException("We are unable to process a filing for this PSC", new Exception("Internal Id"));
         }
 
         var internalData = InternalData.newBuilder().internalId(String.valueOf(pscIndividualFullRecordApi.getInternalId())).build();

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
@@ -99,13 +99,11 @@ public class PscVerificationControllerImpl implements PscVerificationController 
         final var entity = filingMapper.toEntity(data);
 
         PscIndividualFullRecordApi pscIndividualFullRecordApi;
-        try {
-            pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(requestTransaction, data, PscType.INDIVIDUAL);
-        } catch (PscLookupServiceException e) {
-            throw new FilingResourceNotFoundException("PSC Notification Id not found");
-        }
+        pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(requestTransaction, data, PscType.INDIVIDUAL);
 
         if (pscIndividualFullRecordApi.getInternalId() == null) {
+            logMap.put("psc_notification_id", data.pscNotificationId());
+            logger.errorContext(String.format("PSC Id %s does not have an Internal ID in PSC Data API for company number %s", data.pscNotificationId(), data.companyNumber()), null, logMap);
             throw new PscLookupServiceException("We are currently unable to process a Verification filing for this PSC", new Exception("Internal Id"));
         }
 

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
@@ -106,7 +106,7 @@ public class PscVerificationControllerImpl implements PscVerificationController 
         }
 
         if (pscIndividualFullRecordApi.getInternalId() == null) {
-            throw new PscLookupServiceException("We are unable to process a filing for this PSC", new Exception("Internal Id"));
+            throw new PscLookupServiceException("We are currently unable to process a Verification filing for this PSC", new Exception("Internal Id"));
         }
 
         var internalData = InternalData.newBuilder().internalId(String.valueOf(pscIndividualFullRecordApi.getInternalId())).build();

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerification.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerification.java
@@ -28,6 +28,7 @@ public final class PscVerification implements Touchable {
     @JsonMerge
     @JsonProperty("data")
     private PscVerificationData data;
+    // No @JsonMerge: this property MUST NOT be modifiable by PATCH requests
     @JsonProperty("internal_data")
     private InternalData internalData;
 

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerification.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerification.java
@@ -9,6 +9,7 @@ import java.util.StringJoiner;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import uk.gov.companieshouse.api.model.common.ResourceLinks;
+import uk.gov.companieshouse.api.model.pscverification.InternalData;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 
 @Document(collection = "psc_verification")
@@ -27,6 +28,8 @@ public final class PscVerification implements Touchable {
     @JsonMerge
     @JsonProperty("data")
     private PscVerificationData data;
+    @JsonProperty("internal_data")
+    private InternalData internalData;
 
     public PscVerification() {
         // required by Spring Data
@@ -38,6 +41,7 @@ public final class PscVerification implements Touchable {
         setUpdatedAt(builder.updatedAt);
         setLinks(builder.links);
         setData(builder.data);
+        setInternalData(builder.internalData);
     }
 
     public static Builder newBuilder() {
@@ -51,6 +55,7 @@ public final class PscVerification implements Touchable {
         builder.updatedAt = copy.getUpdatedAt();
         builder.links = copy.getLinks();
         builder.data = copy.getData();
+        builder.internalData = copy.getInternalData();
         return builder;
     }
 
@@ -74,6 +79,10 @@ public final class PscVerification implements Touchable {
         return data;
     }
 
+    public InternalData getInternalData() {
+        return internalData;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -81,12 +90,12 @@ public final class PscVerification implements Touchable {
         return Objects.equals(getId(), that.getId()) && Objects.equals(getCreatedAt(),
             that.getCreatedAt()) && Objects.equals(getUpdatedAt(),
             that.getUpdatedAt()) && Objects.equals(getLinks(), that.getLinks()) && Objects.equals(
-            getData(), that.getData());
+            getData(), that.getData()) && Objects.equals(getInternalData(), that.getInternalData());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getCreatedAt(), getUpdatedAt(), getLinks(), getData());
+        return Objects.hash(getId(), getCreatedAt(), getUpdatedAt(), getLinks(), getData(), getInternalData());
     }
 
     @Override
@@ -97,6 +106,7 @@ public final class PscVerification implements Touchable {
             .add("updatedAt=" + getUpdatedAt())
             .add("links=" + getLinks())
             .add("data=" + getData())
+            .add("internalData=" + getInternalData())
             .toString();
     }
 
@@ -120,6 +130,10 @@ public final class PscVerification implements Touchable {
         this.data = data;
     }
 
+    public void setInternalData(final InternalData internalData) {
+        this.internalData = internalData;
+    }
+
     @Override
     public void touch(Instant instant) {
         this.updatedAt = instant;
@@ -134,6 +148,7 @@ public final class PscVerification implements Touchable {
         private Instant updatedAt;
         private ResourceLinks links;
         private PscVerificationData data;
+        private InternalData internalData;
 
         private Builder() {
         }
@@ -195,6 +210,18 @@ public final class PscVerification implements Touchable {
          */
         public Builder data(final PscVerificationData data) {
             this.data = data;
+            return this;
+        }
+
+        /**
+         * Sets the {@code internalData} and returns a reference to this Builder so that the methods can be
+         * chained together.
+         *
+         * @param internalData the {@code internalData} to set
+         * @return a reference to this Builder
+         */
+        public Builder internalData(final InternalData internalData) {
+            this.internalData = internalData;
             return this;
         }
 

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/model/mapper/PscVerificationMapper.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/model/mapper/PscVerificationMapper.java
@@ -24,6 +24,7 @@ public interface PscVerificationMapper {
 
     @Mapping(target = "etag", ignore = true)
     @Mapping(target = "kind", ignore = true)
+    @Mapping(target = "internalData", ignore = true)
     PscVerificationApi toApi(final PscVerification verification);
 
     PscVerificationDataForUpdating toForUpdating(final PscVerificationData data);

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplIT.java
@@ -50,10 +50,10 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.error.RestExceptionHandler;
 import uk.gov.companieshouse.pscverificationapi.model.entity.PscVerification;
 import uk.gov.companieshouse.pscverificationapi.model.mapper.PscVerificationMapperImpl;
-import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 import uk.gov.companieshouse.pscverificationapi.service.PscVerificationService;
 import uk.gov.companieshouse.pscverificationapi.service.TransactionService;
 import uk.gov.companieshouse.pscverificationapi.service.VerificationValidationService;
+import uk.gov.companieshouse.pscverificationapi.service.impl.PscLookupServiceImpl;
 
 @Tag("web")
 @WebMvcTest(controllers = PscVerificationControllerImpl.class)
@@ -71,7 +71,7 @@ class PscVerificationControllerImplIT extends BaseControllerIT {
     @MockBean
     private TransactionService transactionService;
     @MockBean
-    private PscLookupService lookupService;
+    private PscLookupServiceImpl lookupService;
     @MockBean
     private PscVerificationService pscVerificationService;
     @MockBean

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplIT.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplIT.java
@@ -44,9 +44,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.model.common.ResourceLinks;
 import uk.gov.companieshouse.api.model.psc.PscApi;
+import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.pscverification.RelevantOfficer;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.error.RestExceptionHandler;
 import uk.gov.companieshouse.pscverificationapi.model.entity.PscVerification;
 import uk.gov.companieshouse.pscverificationapi.model.mapper.PscVerificationMapperImpl;
@@ -80,6 +82,8 @@ class PscVerificationControllerImplIT extends BaseControllerIT {
     private RestExceptionHandler restExceptionHandler;
     @MockBean
     private PscApi pscDetails;
+    @MockBean
+    private PscIndividualFullRecordApi pscIndividualFullRecordApi;
     @MockBean
     private MongoDatabaseFactory mongoDatabaseFactory;
     @SpyBean
@@ -147,6 +151,7 @@ class PscVerificationControllerImplIT extends BaseControllerIT {
             .thenAnswer(i -> PscVerification.newBuilder(i.getArgument(0)).build()
                 // copy of first argument
             );
+        when(lookupService.getPscIndividualFullRecord(transaction, dto, PscType.INDIVIDUAL)).thenReturn(pscIndividualFullRecordApi);
         when(clock.instant()).thenReturn(FIRST_INSTANT);
 
         final var expectedStatementNames = isRLE ? List.of(RO_IDENTIFIED.toString(),

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
@@ -174,7 +174,7 @@ class PscVerificationControllerImplTest {
         when(pscLookupService.getPscIndividualFullRecord(transaction, filing, PscType.INDIVIDUAL))
                 .thenThrow(new PscLookupServiceException("msg", null));
 
-        assertThrows(FilingResourceNotFoundException.class,
+        assertThrows(PscLookupServiceException.class,
                 () ->testController.createPscVerification(TRANS_ID, transaction, filing, result, request));
     }
 

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerificationTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerificationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.common.ResourceLinks;
 import uk.gov.companieshouse.api.model.psc.NameElementsApi;
+import uk.gov.companieshouse.api.model.pscverification.InternalData;
 import uk.gov.companieshouse.api.model.pscverification.NameMismatchReasonConstants;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.pscverification.RelevantOfficer;
@@ -34,6 +35,7 @@ class PscVerificationTest {
     private PscVerification testVerification;
     private ResourceLinks links;
     private PscVerificationData data;
+    private InternalData internalData;
     private VerificationDetails verif;
     private RelevantOfficer relevantOfficer;
     private NameElementsApi nameElements;
@@ -67,12 +69,14 @@ class PscVerificationTest {
             .verificationDetails(verif)
             .relevantOfficer(relevantOfficer)
             .build();
+        internalData = InternalData.newBuilder().internalId("123").build();
         testVerification = PscVerification.newBuilder()
             .id("id")
             .createdAt(INSTANT)
             .updatedAt(INSTANT)
             .links(links)
             .data(data)
+            .internalData(internalData)
             .build();
     }
 
@@ -107,6 +111,7 @@ class PscVerificationTest {
                 + "surname='Surname'], "
                 + "dateOfBirth=1990-12-31, isEmployee=true, isDirector=true], "
                 + "verificationDetails=VerificationDetails[uvid='uvid', "
-                + "nameMismatchReason=PREFERRED_NAME, statements=[INDIVIDUAL_VERIFIED]]]]"));
+                + "nameMismatchReason=PREFERRED_NAME, statements=[INDIVIDUAL_VERIFIED]]], "
+                + "internalData=InternalData[internalId=123]]"));
     }
 }


### PR DESCRIPTION
Add lookup, handling and storing of Internal Id upon POST of Verification

SDK changes done and approved in https://github.com/companieshouse/api-sdk-java/pull/391

IDVA3-2926

If PSC Id does not exits:

![Screenshot 2025-03-19 at 12 05 32 pm](https://github.com/user-attachments/assets/45075dbd-79f5-4034-a094-2428b73f8dc5)

If Internal Id is missing on PSC:

![Screenshot 2025-03-19 at 12 19 31 pm](https://github.com/user-attachments/assets/2c774af5-0d15-4490-a508-53f0154a725c)

Note have updated `spring-boot-dependencies.version` to 3.4.3 to remove `tomcat-embed-core` vulnerability