### PR TITLE
IDVA3-2957 Add null check to PscIsPastStartDateValidator

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsPastStartDateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsPastStartDateValidator.java
@@ -8,15 +8,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
 
 import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
 @Component
 public class PscIsPastStartDateValidator extends BaseVerificationValidator implements VerificationValidator {
     private final PscLookupService pscLookupService;
+    private final Logger logger;
 
-    public PscIsPastStartDateValidator(Map<String, String> validation, PscLookupService pscLookupService) {
+    public PscIsPastStartDateValidator(Map<String, String> validation, PscLookupService pscLookupService, Logger logger) {
         super(validation);
         this.pscLookupService = pscLookupService;
+        this.logger = logger;
     }
 
     @Override
@@ -24,14 +27,22 @@ public class PscIsPastStartDateValidator extends BaseVerificationValidator imple
         PscIndividualFullRecordApi pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(
                 validationContext.transaction(), validationContext.dto(), validationContext.pscType());
 
-        final var startDate = pscIndividualFullRecordApi.getVerificationState().verificationStartDate();
-        final var formattedStartDate = startDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        final var verificationState = pscIndividualFullRecordApi.getVerificationState();
 
-        if (startDate != null && LocalDate.now().isBefore(startDate)) {
-            final var errorResponseText = validation.get("psc-cannot-verify-yet").replace("{start-date}", formattedStartDate);
-            validationContext.errors().add(
-                    new FieldError("object", "psc_verification_start_date", formattedStartDate, false,
-                            new String[] { null, formattedStartDate }, null, errorResponseText));
+        if (verificationState == null) {
+            logger.info(String.format(
+                "Validation for PSC start date skipped due to null verification state. [Company number: %s, PSC notification ID: %s]",
+                validationContext.dto().companyNumber(), validationContext.dto().pscNotificationId()));
+        } else {
+            final var startDate = verificationState.verificationStartDate();
+
+            if (startDate != null && LocalDate.now().isBefore(startDate)) {
+                final var formattedStartDate = startDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+                final var errorResponseText = validation.get("psc-cannot-verify-yet").replace("{start-date}", formattedStartDate);
+                validationContext.errors().add(
+                        new FieldError("object", "psc_verification_start_date", formattedStartDate, false,
+                                new String[] { null, formattedStartDate }, null, errorResponseText));
+            }
         }
 
         super.validate(validationContext);

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsPastStartDateValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsPastStartDateValidatorTest.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.api.model.psc.VerificationState;
 import uk.gov.companieshouse.api.model.psc.VerificationStatus;
 import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.enumerations.PscType;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
@@ -40,6 +41,8 @@ class PscIsPastStartDateValidatorTest {
     private Transaction transaction;
     @Mock
     private PscIndividualFullRecordApi pscIndividualFullRecord;
+    @Mock
+    private Logger logger;
 
     PscIsPastStartDateValidator testValidator;
     private PscType pscType;
@@ -53,9 +56,22 @@ class PscIsPastStartDateValidatorTest {
         pscType = PscType.INDIVIDUAL;
         passthroughHeader = "passthroughHeader";
 
-        testValidator = new PscIsPastStartDateValidator(validation, pscLookupService);
+        testValidator = new PscIsPastStartDateValidator(validation, pscLookupService, logger);
         when(pscLookupService.getPscIndividualFullRecord(transaction, pscVerificationData, pscType))
                 .thenReturn(pscIndividualFullRecord);
+    }
+
+    @Test
+    void validateWhenVerificationStateIsNull() {
+        when(pscIndividualFullRecord.getVerificationState()).thenReturn(null);
+
+        when(pscLookupService.getPscIndividualFullRecord(transaction, pscVerificationData, pscType))
+                .thenReturn(pscIndividualFullRecord);
+            testValidator.validate(
+                    new VerificationValidationContext(pscVerificationData, errors, transaction, pscType,
+                                                      passthroughHeader));
+
+        assertThat(errors, is(empty()));
     }
 
     @Test


### PR DESCRIPTION
# [IDVA3-2957](https://companieshouse.atlassian.net/browse/IDVA3-2957) Add null check to PscIsPastStartDateValidator 

Log looks something like:
`2025-03-26T15:28:53.196Z info: Validation for PSC start date skipped due to null verification state. [Company number: 00006400, PSC notification ID: PSCDATA5]`

Test by giving a PSC an internal id that doesn't match any row in the IDV_DETAIL table.

[IDVA3-2957]: https://companieshouse.atlassian.net/browse/IDVA3-2957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ