### PR TITLE
Remove RLE filing kind

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/model/FilingKind.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/model/FilingKind.java
@@ -5,8 +5,7 @@ import java.util.Optional;
 
 public enum FilingKind {
 
-    PSC_VERIFICATION_INDIVIDUAL("psc-verification#psc-verification-individual"),
-    PSC_VERIFICATION_RLE_RO("psc-verification#psc-verification-rle-ro");
+    PSC_VERIFICATION_INDIVIDUAL("psc-verification#psc-verification-individual");
 
     FilingKind(final String value) {
         this.value = value;

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/service/impl/FilingDataServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/service/impl/FilingDataServiceImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.pscverificationapi.service.impl;
 
 import static uk.gov.companieshouse.pscverificationapi.model.FilingKind.PSC_VERIFICATION_INDIVIDUAL;
-import static uk.gov.companieshouse.pscverificationapi.model.FilingKind.PSC_VERIFICATION_RLE_RO;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.stereotype.Service;
@@ -11,7 +10,6 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.config.FilingDataConfig;
 import uk.gov.companieshouse.pscverificationapi.exception.FilingResourceNotFoundException;
 import uk.gov.companieshouse.pscverificationapi.helper.LogMapHelper;
-import uk.gov.companieshouse.pscverificationapi.model.entity.PscVerification;
 import uk.gov.companieshouse.pscverificationapi.service.FilingDataService;
 import uk.gov.companieshouse.pscverificationapi.service.PscVerificationService;
 import uk.gov.companieshouse.pscverificationapi.utils.MapHelper;
@@ -45,7 +43,7 @@ public class FilingDataServiceImpl implements FilingDataService {
                 String.format("PSC verification not found when generating filing for %s", filingId)));
 
         final var filingApi = new FilingApi();
-        filingApi.setKind(determineFilingKind(pscVerification));
+        filingApi.setKind(PSC_VERIFICATION_INDIVIDUAL.getValue());
         filingApi.setDescription(filingDataConfig.getPscVerificationDescription());
 
         final var dataMap = MapHelper.convertObject(pscVerification.getData(), PropertyNamingStrategies.SNAKE_CASE);
@@ -58,12 +56,4 @@ public class FilingDataServiceImpl implements FilingDataService {
         return filingApi;
     }
 
-    private String determineFilingKind(PscVerification pscVerification) {
-        if (pscVerification.getData().relevantOfficer() == null) {
-            return PSC_VERIFICATION_INDIVIDUAL.getValue();
-        }
-        else {
-            return PSC_VERIFICATION_RLE_RO.getValue();
-        }
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/model/FilingKindTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/model/FilingKindTest.java
@@ -20,15 +20,6 @@ class FilingKindTest {
     void nameOfPscVerificationIndividualWhenFound() {
         assertThat(FilingKind.nameOf("psc-verification#psc-verification-individual"), is(Optional.of(FilingKind.PSC_VERIFICATION_INDIVIDUAL)));
     }
-    @Test
-    void getValuePscVerificationRleRo() {
-        assertThat(FilingKind.PSC_VERIFICATION_RLE_RO.getValue(), is("psc-verification#psc-verification-rle-ro"));
-    }
-
-    @Test
-    void nameOfPscVerificationRleRoWhenFound() {
-        assertThat(FilingKind.nameOf("psc-verification#psc-verification-rle-ro"), is(Optional.of(FilingKind.PSC_VERIFICATION_RLE_RO)));
-    }
 
     @Test
     void nameOfWhenNotFound() {

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/FilingDataServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/service/impl/FilingDataServiceImplTest.java
@@ -105,64 +105,6 @@ class FilingDataServiceImplTest {
     }
 
     @Test
-    void generatePscVerificationRleRoFilingWhenFound() {
-        final var verificationDetails = VerificationDetails.newBuilder()
-                .uvid(UVID)
-                .nameMismatchReason(PREFERRED_NAME)
-                .statements(EnumSet.of(RO_IDENTIFIED))
-                .build();
-        final var nameElements = new NameElementsApi();
-                nameElements.setTitle(TITLE);
-                nameElements.setForename(FORENAME);
-                nameElements.setOtherForenames(OTHER_FORENAMES);
-                nameElements.setSurname(SURNAME);
-        final var relevantOfficer = RelevantOfficer.newBuilder()
-                .nameElements(nameElements)
-                .dateOfBirth(DATE_OF_BIRTH)
-                .isDirector(true)
-                .isEmployee(true)
-                .build();
-        final var data = PscVerificationData.newBuilder()
-                .companyNumber(COMPANY_NUMBER)
-                .pscNotificationId(PSC_NOTIFICATION_ID)
-                .verificationDetails(verificationDetails)
-                .relevantOfficer(relevantOfficer)
-                .build();
-        final var internalData = InternalData.newBuilder()
-                .internalId(APPOINTMENT_ID)
-                .build();
-        final var filingData = PscVerification.newBuilder()
-                .data(data)
-                .internalData(internalData)
-                .build();
-
-        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(filingData));
-        when(filingDataConfig.getPscVerificationDescription()).thenReturn(PSC_VERIFICATION);
-
-        final var filingApi = testService.generateFilingApi(FILING_ID, transaction);
-
-        final Map<String, Object> expectedMap;
-        final String expectedDescription;
-
-        expectedMap = Map.of("company_number", COMPANY_NUMBER,
-                "appointment_id", APPOINTMENT_ID,
-                "verification_details", Map.of("name_mismatch_reason", "PREFERRED_NAME",
-                        "verification_statements", List.of("RO_IDENTIFIED"),
-                        "uvid", UVID),
-                "relevant_officer", Map.of("name_elements",
-                                Map.of("title", TITLE, "forename", FORENAME,
-                                        "other_forenames", OTHER_FORENAMES, "surname", SURNAME),
-                        "date_of_birth", DATE_OF_BIRTH.toString(),
-                        "is_employee", true,
-                        "is_director", true)
-        );
-        expectedDescription = PSC_VERIFICATION;
-        assertThat(filingApi.getData(), is(equalTo(expectedMap)));
-        assertThat(filingApi.getKind(), is(FilingKind.PSC_VERIFICATION_RLE_RO.getValue()));
-        assertThat(filingApi.getDescription(), is(expectedDescription));
-    }
-
-    @Test
     void generatePscIndividualFilingWhenNotFound() {
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
Remove RLE Filing Kind

Note - we've decided to leave the remaining kind as `"psc-verification#psc-verification-individual"` for 2 reasons:
- RLE may come back in later
- also it makes it explicit that the Verification is for an Individual

IDVA3-2842

see CHIPS Filing Consumer PR where testing is shown - https://github.com/companieshouse/chips-filing-consumer/pull/350