### PR TITLE
Add lookup of internal id if PSC is being patched

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
@@ -109,7 +109,8 @@ public class PscVerificationControllerImpl implements PscVerificationController 
             logMap.put("psc_notification_id", data.pscNotificationId());
             logger.errorContext(String.format("PSC Id %s does not have an Internal ID in PSC Data API for company number %s",
                     data.pscNotificationId(), data.companyNumber()), null, logMap);
-            throw new PscLookupServiceException("We are currently unable to process a Verification filing for this PSC", new Exception("Internal Id"));
+            throw new PscLookupServiceException(
+                    "We are currently unable to process a Verification filing for this PSC", new Exception("Internal Id"));
         }
 
         var internalData = InternalData.newBuilder().internalId(String.valueOf(pscIndividualFullRecordApi.getInternalId())).build();
@@ -141,8 +142,7 @@ public class PscVerificationControllerImpl implements PscVerificationController 
 
         PscIndividualFullRecordApi pscIndividualFullRecordApi = null;
         if (mergePatch.get("psc_notification_id") != null && pscVerification.isPresent()) {
-            final var transaction = getTransaction(transId, null, logMap,
-                    getPassthroughHeader(request));
+            final var transaction = getTransaction(transId, null, logMap, getPassthroughHeader(request));
 
             String companyNumber = mergePatch.get("company_number") != null
                     ? mergePatch.get("company_number").toString()
@@ -158,8 +158,9 @@ public class PscVerificationControllerImpl implements PscVerificationController 
             if (pscIndividualFullRecordApi.getInternalId() == null) {
                 logMap.put("psc_notification_id", mergePatch.get("psc_notification_id"));
                 logger.errorContext(String.format("PSC Id %s does not have an Internal ID in PSC Data API for company number %s",
-                        mergePatch.get("psc_notification_id"), pscVerification.orElseThrow().getData().companyNumber()),null, logMap);
-                throw new PscLookupServiceException("We are currently unable to process a Verification filing for this PSC", new Exception("Internal Id"));
+                        mergePatch.get("psc_notification_id"), companyNumber),null, logMap);
+                throw new PscLookupServiceException(
+                        "We are currently unable to process a Verification filing for this PSC", new Exception("Internal Id"));
             }
         }
 

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerification.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/model/entity/PscVerification.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.pscverificationapi.model.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonMerge;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,6 +15,7 @@ import uk.gov.companieshouse.api.model.pscverification.PscVerificationData;
 
 @Document(collection = "psc_verification")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class PscVerification implements Touchable {
     @Id
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
@@ -63,6 +63,7 @@ import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 class PscVerificationControllerImplTest {
     public static final String TRANS_ID = "117524-754816-491724";
     private static final String PSC_ID = "1kdaTltWeaP1EB70SSD9SLmiK5Y";
+    private static final String PSC_ID_TO_PATCH = "123456789";
     private static final String COMPANY_NUMBER = "00006400";
     private static final String UVID = "0xDEADBEEF";
     private static final String PASSTHROUGH_HEADER = "passthrough";
@@ -226,6 +227,57 @@ class PscVerificationControllerImplTest {
             is(not(equalTo(response.getBody().getCreatedAt()))));
         assertThat(response.getHeaders().getLocation(), is(entityWithLinks.getLinks().self()));
 
+    }
+
+    @Test
+    void updatePscVerificationWithPscNotificationIdAndInternalId() {
+        final var success = new PatchResult();
+        final var updatedEntity = PscVerification.newBuilder(entityWithLinks)
+                .updatedAt(SECOND_INSTANT)
+                .build();
+        final var dataToLookup = PscVerificationData.newBuilder(filing).pscNotificationId(PSC_ID_TO_PATCH).build();
+        mergePatch.put("psc_notification_id", PSC_ID_TO_PATCH);
+
+        when(transactionService.getTransaction(TRANS_ID, null)).thenReturn(transaction);
+        when(pscLookupService.getPscIndividualFullRecord(transaction, dataToLookup, PscType.INDIVIDUAL))
+                .thenReturn(pscIndividualFullRecordApi);
+        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks))
+                .thenReturn(Optional.of(updatedEntity));
+        when(pscVerificationService.requestMatchesResourceSelf(request, entityWithLinks)).thenReturn(true);
+        when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
+
+        final var response = testController.updatePscVerification(TRANS_ID, FILING_ID, mergePatch, request);
+        final var expectedBody = filingMapper.toApi(updatedEntity);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(notNullValue()));
+        assertThat(response.getBody(), is(expectedBody));
+        assertThat(response.getBody().getUpdatedAt(),
+                is(not(equalTo(response.getBody().getCreatedAt()))));
+        assertThat(response.getHeaders().getLocation(), is(entityWithLinks.getLinks().self()));
+    }
+
+    @Test
+    void updatePscVerificationWithPscNotificationIdThrowsPscLookupExceptionWhenNoInternalId() {
+        final var success = new PatchResult();
+        final var updatedEntity = PscVerification.newBuilder(entityWithLinks)
+                .updatedAt(SECOND_INSTANT)
+                .build();
+        mergePatch.put("psc_notification_id", PSC_ID_TO_PATCH);
+        PscVerificationData dataToLookup = PscVerificationData.newBuilder(filing).pscNotificationId(PSC_ID_TO_PATCH).build();
+        pscIndividualFullRecordApi.setInternalId(null);
+
+        when(transactionService.getTransaction(TRANS_ID, null)).thenReturn(transaction);
+        when(pscLookupService.getPscIndividualFullRecord(transaction, dataToLookup, PscType.INDIVIDUAL))
+                .thenReturn(pscIndividualFullRecordApi);
+        when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks))
+                .thenReturn(Optional.of(updatedEntity));
+        when(pscVerificationService.requestMatchesResourceSelf(request, entityWithLinks)).thenReturn(true);
+        when(pscVerificationService.patch(eq(FILING_ID), anyMap())).thenReturn(success);
+
+        assertThrows(PscLookupServiceException.class,
+                () ->testController.updatePscVerification(TRANS_ID, FILING_ID,
+                mergePatch, request));
     }
 
     @Test


### PR DESCRIPTION
Code added to Patch controller, to amend the internal Id that is stored in the Verification, if the supplied `"psc_notification_id"` is changed

IDVA3-2928