### PR TITLE
Re throw PscLookupServiceException

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImpl.java
@@ -102,10 +102,11 @@ public class PscVerificationControllerImpl implements PscVerificationController 
             getPassthroughHeader(request));
 
         final var entity = filingMapper.toEntity(data);
-        final var pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(
-            requestTransaction, data, PscType.INDIVIDUAL);
-
-        if (pscIndividualFullRecordApi.getInternalId() == null) {
+        final PscIndividualFullRecordApi pscIndividualFullRecordApi;
+        try {
+            pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(
+                    requestTransaction, data, PscType.INDIVIDUAL);
+        } catch (PscLookupServiceException e) {
             logMap.put("psc_notification_id", data.pscNotificationId());
             logger.errorContext(String.format("PSC Id %s does not have an Internal ID in PSC Data API for company number %s",
                     data.pscNotificationId(), data.companyNumber()), null, logMap);

--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
@@ -180,16 +180,6 @@ class PscVerificationControllerImplTest {
     }
 
     @Test
-    void createPscVerifcationThrowsPscLookupExceptionWhenNoInternalId() {
-        pscIndividualFullRecordApi.setInternalId(null);
-        when(pscLookupService.getPscIndividualFullRecord(transaction, filing, PscType.INDIVIDUAL))
-                .thenReturn(pscIndividualFullRecordApi);
-
-        assertThrows(PscLookupServiceException.class,
-                () ->testController.createPscVerification(TRANS_ID, transaction, filing, result, request));
-    }
-
-    @Test
     void getPscVerificationWhenFound() {
 
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks));


### PR DESCRIPTION
**Jira ticket**: Needed for IDVA3-3321

## Re-throw PscLookupServiceException
This is for the case of a failed Full record call due to their not being an internal id in the db.  The exception can be re thrown with the error message that the PSC Web expects and it will display the appropriate page to the user.  Attempting to check the `pscIndividualFullRecordApi` will always fail.
I've removed a unit test, because this scenario is covered in the test above it.

## Working example
With this code in the PSC Verify Web I can reach this:

<img width="971" alt="Screenshot 2025-07-07 at 1 57 19 pm" src="https://github.com/user-attachments/assets/2412308a-da23-4969-a218-edb0084dd1c6" />

## Test notes
Attempt to progress to Personal Code screen for a PSC which does not have an internal id in the database

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [x] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
