### PR TITLE
IDVA3-3386, IDVA3-3387 & IDVA3-3388 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <structured-logging.version>3.0.38</structured-logging.version>
         <api-security-java.version>2.0.10</api-security-java.version>
         <api-helper-java.version>3.0.1</api-helper-java.version>
-        <api-sdk-java.version>6.4.1</api-sdk-java.version>
+        <api-sdk-java.version>6.4.4</api-sdk-java.version>
         <sdk-manager-java.version>3.0.11</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>4.0.331</private-api-sdk-java.version>

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsPastStartDateValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsPastStartDateValidator.java
@@ -11,32 +11,52 @@ import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
+/**
+ * Validator to check if a Person with Significant Control (PSC) can be verified
+ * based on the appointment verification statement start date.
+ * <p>
+ * If the start date is in the future, an error is added to the validation context.
+ * </p>
+ */
 @Component
 public class PscIsPastStartDateValidator extends BaseVerificationValidator implements VerificationValidator {
     private final PscLookupService pscLookupService;
     private final Logger logger;
 
+    /**
+     * Constructs a new {@code PscIsPastStartDateValidator}.
+     *
+     * @param validation a map of validation messages or configurations
+     * @param pscLookupService the service used to retrieve PSC details
+     * @param logger the logger for logging validation events
+     */
     public PscIsPastStartDateValidator(Map<String, String> validation, PscLookupService pscLookupService, Logger logger) {
         super(validation);
         this.pscLookupService = pscLookupService;
         this.logger = logger;
     }
 
+    /**
+     * Validates whether the PSC can be verified based on the appointment verification statement start date.
+     * <p>
+     * If the identity verification details are null, logs the event and skips validation.
+     * If the start date is in the future, adds a validation error.
+     * */
     @Override
     public void validate(VerificationValidationContext validationContext) {
         PscIndividualFullRecordApi pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(
                 validationContext.transaction(), validationContext.dto(), validationContext.pscType());
 
-        final var verificationState = pscIndividualFullRecordApi.getVerificationState();
+        final var identityVerificationDetails = pscIndividualFullRecordApi.getIdentityVerificationDetails();
 
-        if (verificationState == null) {
+        if (identityVerificationDetails == null) {
             logger.info(String.format(
-                "Validation for PSC start date skipped due to null verification state. [Company number: %s, PSC notification ID: %s]",
+                "Validation for PSC start date skipped due to null identity verification details. [Company number: %s, PSC notification ID: %s]",
                 validationContext.dto().companyNumber(), validationContext.dto().pscNotificationId()));
         } else {
-            final var startDate = verificationState.verificationStartDate();
+            final var startDate = identityVerificationDetails.appointmentVerificationStatementDate();
 
-            if (startDate != null && LocalDate.now().isBefore(startDate)) {
+            if (startDate != null && startDate.isAfter(LocalDate.now())) {
                 final var formattedStartDate = startDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
                 final var errorResponseText = validation.get("psc-cannot-verify-yet").replace("{start-date}", formattedStartDate);
                 validationContext.errors().add(

--- a/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsUnverifiedValidator.java
+++ b/src/main/java/uk/gov/companieshouse/pscverificationapi/validator/PscIsUnverifiedValidator.java
@@ -1,34 +1,75 @@
 package uk.gov.companieshouse.pscverificationapi.validator;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
 import org.springframework.validation.FieldError;
-
 import uk.gov.companieshouse.api.model.psc.PscIndividualFullRecordApi;
-import uk.gov.companieshouse.api.model.psc.VerificationStatus;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscverificationapi.service.PscLookupService;
 
+/**
+ * Validator to check if a PSC (Person with Significant Control) is unverified.
+ * Determines unverified status based on identity verification details, such as
+ * the absence of an appointment verification start date or a revoked verification.
+ */
 @Component
 public class PscIsUnverifiedValidator extends BaseVerificationValidator implements VerificationValidator {
     private final PscLookupService pscLookupService;
+    private final Logger logger;
 
-    public PscIsUnverifiedValidator(Map<String, String> validation, PscLookupService pscLookupService) {
+    /**
+     * Constructs a new {@code PscIsPastStartDateValidator}.
+     *
+     * @param validation a map of validation messages or configurations
+     * @param pscLookupService the service used to retrieve PSC details
+     * @param logger the logger for logging validation events
+     */
+    public PscIsUnverifiedValidator(Map<String, String> validation, PscLookupService pscLookupService, final Logger logger) {
         super(validation);
         this.pscLookupService = pscLookupService;
+        this.logger = logger;
     }
 
+    /**
+     * Validates if the PSC is unverified based on the appointment verification statement start date or if the
+     * appointmentVerificationEndOn date is in the past. If the start date is in the future, a validation error is added.
+     * <p>
+     * If the identity verification details are null, logs the event and skips validation.
+     *
+     * @param validationContext the context containing transaction, DTO, and PSC type information.
+     */
     @Override
     public void validate(VerificationValidationContext validationContext) {
         PscIndividualFullRecordApi pscIndividualFullRecordApi = pscLookupService.getPscIndividualFullRecord(
                 validationContext.transaction(), validationContext.dto(), validationContext.pscType());
 
-        var verificationState = pscIndividualFullRecordApi.getVerificationState();
-        if (verificationState != null && verificationState.verificationStatus() == VerificationStatus.VERIFIED) {
-            validationContext.errors().add(
-                    new FieldError("object", "psc_verification_status", verificationState.verificationStatus(), false,
-                            new String[] { null, verificationState.verificationStatus().toString() }, null,
-                            validation.get("psc-already-verified")));
+        var identityVerificationDetails = pscIndividualFullRecordApi.getIdentityVerificationDetails();
+
+        if (identityVerificationDetails == null) {
+            logger.info(String.format(
+                    "Validation for verification skipped due to null identity verification details. [Company number: %s, PSC notification ID: %s]",
+                    validationContext.dto().companyNumber(), validationContext.dto().pscNotificationId()));
+
+        } else {
+            final var verificationDate = identityVerificationDetails.appointmentVerificationStartOn();
+
+            //if the appointmentVerificationEndOn is in the future, then the PSC is already verified
+            //revoked verifications will have an end date in the past
+            if((identityVerificationDetails.appointmentVerificationEndOn() != null && identityVerificationDetails.appointmentVerificationEndOn().isAfter(LocalDate.now()))
+                    //or if there is an active verification date
+                    || (verificationDate != null && !LocalDate.now().isAfter(verificationDate))
+            ) {
+                // PSC is already verified
+                    final var formattedVerificationDate = verificationDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+                    final var errorResponseText = validation.get("psc-already-verified").replace("{appointment_verification_start_on}", formattedVerificationDate);
+
+                    validationContext.errors().add(
+                        new FieldError("object", "appointment_verification_start_on", formattedVerificationDate, false,
+                                new String[]{null, formattedVerificationDate}, null, errorResponseText));
+            }
         }
 
         super.validate(validationContext);


### PR DESCRIPTION
… data model changes

**Jira tickets**: IDVA3-3386, IDVA3-3387 & IDVA3-3388 

## Brief description of the change(s)
Refactor of validators following verification data model updates. Applies to the following validators:

- `PscIsPastStartDateValidator`
- `PscIsUnverifiedValidator`

Validation
- If the identity verification details are null, an event is logged and validation is skipped.
- If the verification start date is in the future, a validation error is added.
- If the PSC is already verified, a validation error is added.
- If the PSC validation is revoked and the verification has ended, then the PSC may be verified.

## Working example
PSC already verified:
<img width="1463" height="954" alt="PSC Already verified" src="https://github.com/user-attachments/assets/8c5e811c-cfbd-4700-a393-be4b9b296d7c" />

PSC can be verified:
<img width="1276" height="689" alt="PSC verification statement date is now or in the past" src="https://github.com/user-attachments/assets/8c9fbf62-bd63-4c24-af77-c31410ef2d89" />

PSC cannot verify yet:
<img width="1281" height="854" alt="PSC verification statement date in future" src="https://github.com/user-attachments/assets/ca5d545f-59a8-44b1-b8d9-530b9d1cdbfe" />

Missing internal ID:
<img width="1287" height="808" alt="Missing PSC internal ID" src="https://github.com/user-attachments/assets/85a833f4-dc6f-4a93-9cdc-32ff9bf7e141" />

## Test notes
>
> Add test notes only if they're **not** already included in the Jira ticket.

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [x] Added/updated logging appropriately.
- [x] Written tests.
- [x] Tested the new code in my local environment.
~~- [ ] Updated Docker/ECS configs.~~
~~- [ ] Added all new properties to chs-configs.~~
- [x] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
