### PR TITLE
Add a check for the internal Id in the PSC data 

### DIFF
--- a/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscverificationapi/controller/impl/PscVerificationControllerImplTest.java
@@ -180,6 +180,15 @@ class PscVerificationControllerImplTest {
     }
 
     @Test
+    void createPscVerificationThrowsPscLookupExceptionWhenNoInternalId() {
+        when(pscLookupService.getIndividualFullRecord(transaction, filing, PscType.INDIVIDUAL))
+                .thenReturn(new IndividualFullRecord());
+
+        assertThrows(PscLookupServiceException.class,
+                () ->testController.createPscVerification(TRANS_ID, transaction, filing, result, request));
+    }
+
+    @Test
     void getPscVerificationWhenFound() {
 
         when(pscVerificationService.get(FILING_ID)).thenReturn(Optional.of(entityWithLinks));


### PR DESCRIPTION
**Jira ticket**: IDVA3-3691

## Brief description of the change(s)
Add a check for the internal Id in the PSC data and pass exception, so that PSC verify Web will know to display it's problem with data page

## Working example
In this scenario, this screen should display in the web instead of the Personal code screen
<img width="978" height="509" alt="Screenshot 2025-09-24 at 2 48 24 pm" src="https://github.com/user-attachments/assets/16550a00-6e89-4368-a508-48b2d4c205d6" />

<img width="1451" height="483" alt="Screenshot 2025-09-24 at 2 51 34 pm" src="https://github.com/user-attachments/assets/6035d2c9-c01d-43e0-b1d8-ee95af33ffbe" />

## Test notes
- Sirius Black in our Docker db does not have a internal id
- Harry Potter does, so can still proceed to the Personal code screen

## Checklist

- [x] Adhered to the [coding style guidelines](https://companieshouse.atlassian.net/wiki/spaces/DEV/pages/4290084946/Coding+Standards+and+Styleguides).
- [ ] Added/updated logging appropriately.
- [x] Written tests.
- [x] Tested the new code in my local environment.
- [ ] Updated Docker/ECS configs.
- [ ] Added all new properties to chs-configs.
- [ ] Updated release notes.

Strikethrough (`~~like this~~`) anything not applicable to your changes.
